### PR TITLE
Unity support, first draft

### DIFF
--- a/src/Our.Umbraco.IoC.Unity/ContainerBuildingEventArgs.cs
+++ b/src/Our.Umbraco.IoC.Unity/ContainerBuildingEventArgs.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Umbraco.Core;
+using Unity;
+
+namespace Our.Umbraco.IoC.Unity
+{
+    public class ContainerBuildingEventArgs : EventArgs
+    {
+        public ContainerBuildingEventArgs(IUnityContainer container, ApplicationContext appCtx, UmbracoApplicationBase umbApp)
+        {
+            Container = container;
+            AppCtx = appCtx;
+            UmbApp = umbApp;
+        }
+
+        public IUnityContainer Container { get; }
+        public ApplicationContext AppCtx { get; }
+        public UmbracoApplicationBase UmbApp { get; }
+    }
+}

--- a/src/Our.Umbraco.IoC.Unity/Our.Umbraco.IoC.Unity.csproj
+++ b/src/Our.Umbraco.IoC.Unity/Our.Umbraco.IoC.Unity.csproj
@@ -1,0 +1,251 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F4BCEF57-D867-43EE-90DA-7EE849BF11B0}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Our.Umbraco.IoC.Unity</RootNamespace>
+    <AssemblyName>Our.Umbraco.IoC.Unity</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="AutoMapper, Version=3.3.1.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoMapper.3.3.1\lib\net40\AutoMapper.dll</HintPath>
+    </Reference>
+    <Reference Include="AutoMapper.Net4, Version=3.3.1.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoMapper.3.3.1\lib\net40\AutoMapper.Net4.dll</HintPath>
+    </Reference>
+    <Reference Include="businesslogic, Version=1.0.6554.23593, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.7.7\lib\net45\businesslogic.dll</HintPath>
+    </Reference>
+    <Reference Include="ClientDependency.Core, Version=1.9.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ClientDependency.1.9.2\lib\net45\ClientDependency.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="ClientDependency.Core.Mvc, Version=1.8.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ClientDependency-Mvc5.1.8.0.0\lib\net45\ClientDependency.Core.Mvc.dll</HintPath>
+    </Reference>
+    <Reference Include="cms, Version=1.0.6554.23593, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.7.7\lib\net45\cms.dll</HintPath>
+    </Reference>
+    <Reference Include="controls, Version=1.0.6554.23595, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.7.7\lib\net45\controls.dll</HintPath>
+    </Reference>
+    <Reference Include="Examine, Version=0.1.88.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Examine.0.1.88\lib\net45\Examine.dll</HintPath>
+    </Reference>
+    <Reference Include="HtmlAgilityPack, Version=1.4.9.5, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+      <HintPath>..\packages\HtmlAgilityPack.1.4.9.5\lib\Net45\HtmlAgilityPack.dll</HintPath>
+    </Reference>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
+    </Reference>
+    <Reference Include="ImageProcessor, Version=2.5.6.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ImageProcessor.2.5.6\lib\net45\ImageProcessor.dll</HintPath>
+    </Reference>
+    <Reference Include="ImageProcessor.Web, Version=4.8.7.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ImageProcessor.Web.4.8.7\lib\net45\ImageProcessor.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="interfaces, Version=1.0.6554.23582, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.7.7\lib\net45\interfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.7.7\lib\net45\log4net.dll</HintPath>
+    </Reference>
+    <Reference Include="Log4Net.Async, Version=2.0.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Log4Net.Async.2.0.4\lib\net40\Log4Net.Async.dll</HintPath>
+    </Reference>
+    <Reference Include="Lucene.Net, Version=2.9.4.1, Culture=neutral, PublicKeyToken=85089178b9ac3181, processorArchitecture=MSIL">
+      <HintPath>..\packages\Lucene.Net.2.9.4.1\lib\net40\Lucene.Net.dll</HintPath>
+    </Reference>
+    <Reference Include="MarkdownSharp, Version=1.14.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Markdown.1.14.7\lib\net45\MarkdownSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.ApplicationBlocks.Data, Version=1.0.1559.20655, Culture=neutral">
+      <HintPath>..\packages\UmbracoCms.Core.7.7.7\lib\net45\Microsoft.ApplicationBlocks.Data.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNet.Identity.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Identity.Core.2.2.1\lib\net45\Microsoft.AspNet.Identity.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNet.Identity.Owin, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Identity.Owin.2.2.1\lib\net45\Microsoft.AspNet.Identity.Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNet.SignalR.Core, Version=2.2.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.SignalR.Core.2.2.1\lib\net45\Microsoft.AspNet.SignalR.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IO.RecyclableMemoryStream, Version=1.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IO.RecyclableMemoryStream.1.2.2\lib\net45\Microsoft.IO.RecyclableMemoryStream.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.3.1.0\lib\net45\Microsoft.Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Host.SystemWeb, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Host.SystemWeb.3.1.0\lib\net45\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Security, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Security.3.1.0\lib\net45\Microsoft.Owin.Security.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Security.Cookies, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Security.Cookies.3.1.0\lib\net45\Microsoft.Owin.Security.Cookies.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Security.OAuth, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Security.OAuth.3.1.0\lib\net45\Microsoft.Owin.Security.OAuth.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+    </Reference>
+    <Reference Include="MiniProfiler, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b44f9351044011a3, processorArchitecture=MSIL">
+      <HintPath>..\packages\MiniProfiler.2.1.0\lib\net40\MiniProfiler.dll</HintPath>
+    </Reference>
+    <Reference Include="MySql.Data, Version=6.9.10.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL">
+      <HintPath>..\packages\MySql.Data.6.9.10\lib\net45\MySql.Data.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Semver, Version=1.1.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\semver.1.1.2\lib\net45\Semver.dll</HintPath>
+    </Reference>
+    <Reference Include="SQLCE4Umbraco, Version=1.0.6554.23595, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.7.7\lib\net45\SQLCE4Umbraco.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.SqlServerCe, Version=4.0.0.1, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.7.7\lib\net45\System.Data.SqlServerCe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Data.SqlServerCe.Entity, Version=4.0.0.1, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.7.7\lib\net45\System.Data.SqlServerCe.Entity.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Dataflow, Version=4.6.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Dataflow.4.7.0\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http.WebHost, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.3\lib\net45\System.Web.Http.WebHost.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Mvc.5.2.3\lib\net45\System.Web.Mvc.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.3\lib\net45\System.Web.Razor.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="TidyNet, Version=1.0.0.0, Culture=neutral">
+      <HintPath>..\packages\UmbracoCms.Core.7.7.7\lib\net45\TidyNet.dll</HintPath>
+    </Reference>
+    <Reference Include="umbraco, Version=1.0.6554.23596, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.7.7\lib\net45\umbraco.dll</HintPath>
+    </Reference>
+    <Reference Include="Umbraco.Core, Version=1.0.6554.23584, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.7.7\lib\net45\Umbraco.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="umbraco.DataLayer, Version=1.0.6554.23591, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.7.7\lib\net45\umbraco.DataLayer.dll</HintPath>
+    </Reference>
+    <Reference Include="umbraco.editorControls, Version=1.0.6554.23601, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.7.7\lib\net45\umbraco.editorControls.dll</HintPath>
+    </Reference>
+    <Reference Include="umbraco.MacroEngines, Version=1.0.6554.23601, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.7.7\lib\net45\umbraco.MacroEngines.dll</HintPath>
+    </Reference>
+    <Reference Include="umbraco.providers, Version=1.0.6554.23595, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.7.7\lib\net45\umbraco.providers.dll</HintPath>
+    </Reference>
+    <Reference Include="Umbraco.Web.UI, Version=1.0.6554.23602, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.7.7\lib\net45\Umbraco.Web.UI.dll</HintPath>
+    </Reference>
+    <Reference Include="UmbracoExamine, Version=0.7.0.23594, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.7.7\lib\net45\UmbracoExamine.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.Abstractions, Version=3.1.1.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
+      <HintPath>..\packages\Unity.Abstractions.3.1.1\lib\net45\Unity.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.AspNet.WebApi, Version=5.0.11.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
+      <HintPath>..\packages\Unity.AspNet.WebApi.5.0.11\lib\net45\Unity.AspNet.WebApi.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.Container, Version=5.5.2.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
+      <HintPath>..\packages\Unity.Container.5.5.2\lib\net45\Unity.Container.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.Mvc, Version=5.0.12.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
+      <HintPath>..\packages\Unity.Mvc.5.0.12\lib\net45\Unity.Mvc.dll</HintPath>
+    </Reference>
+    <Reference Include="WebActivatorEx, Version=2.0.0.0, Culture=neutral, PublicKeyToken=7b26dc2a43f6a0d4, processorArchitecture=MSIL">
+      <HintPath>..\packages\WebActivatorEx.2.2.0\lib\net40\WebActivatorEx.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\SolutionInfo.cs">
+      <Link>Properties\SolutionInfo.cs</Link>
+    </Compile>
+    <Compile Include="UnityActivator.cs" />
+    <Compile Include="UnityConfig.cs" />
+    <Compile Include="UnityResolver.cs" />
+    <Compile Include="UnityStartup.cs" />
+    <Compile Include="UnityUmbracoRegister.cs" />
+    <Compile Include="ContainerBuildingEventArgs.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UnityWebTypesExtensions.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="Our.Umbraco.IoC.Unity.nuspec" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Our.Umbraco.IoC\Our.Umbraco.IoC.csproj">
+      <Project>{d30131b5-0c54-4cb2-a225-3e80abaa0c3e}</Project>
+      <Name>Our.Umbraco.IoC</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\AutoMapper.3.3.1\tools\AutoMapper.targets" Condition="Exists('..\packages\AutoMapper.3.3.1\tools\AutoMapper.targets')" />
+</Project>

--- a/src/Our.Umbraco.IoC.Unity/Our.Umbraco.IoC.Unity.nuspec
+++ b/src/Our.Umbraco.IoC.Unity/Our.Umbraco.IoC.Unity.nuspec
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<package>
+    <metadata>
+        <id>$id$</id>
+        <version>$version$</version>
+        <title>$title$</title>
+        <authors>Shannon Deminick, Gunnar Már Óttarsson</authors>
+        <owners>Shannon Deminick</owners>
+        <licenseUrl>https://opensource.org/licenses/MIT</licenseUrl>
+        <projectUrl>https://github.com/Shazwazza/Our.Umbraco.IoC</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>A library for easy setup of IoC/Dependency injection for Umbraco with Unity</description>
+        <copyright>$copyright$</copyright>
+        <tags>Umbraco IoC DependencyInjection DI Unity</tags>
+        <dependencies>
+          <dependency id="Our.Umbraco.IoC" version="1.0.0-beta" />
+          <dependency id="UmbracoCms.Core" version="[7.7.0,8.0.0)" />
+          <dependency id="Unity.Abstractions" version="[3.1.1,4.0.0]"  />
+          <dependency id="Unity.AspNet.WebApi" version="[5.0.11,6.0.0]"  />
+          <dependency id="Unity.Container" version="[5.5.2,6.0.0]"  />
+          <dependency id="Unity.Mvc" version="[5.0.12,6.0.0]" />
+          <dependency id="WebActivatorEx" version="[2.2.0,3.0.0]" />
+        </dependencies>
+    </metadata>    
+    <files>
+        <file src="bin\Release\Our.Umbraco.IoC.Unity.dll" target="lib/Our.Umbraco.IoC.Unity.dll"/>
+    </files>
+</package>

--- a/src/Our.Umbraco.IoC.Unity/Properties/AssemblyInfo.cs
+++ b/src/Our.Umbraco.IoC.Unity/Properties/AssemblyInfo.cs
@@ -1,0 +1,33 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Our.Umbraco.IoC.Unity")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyProduct("Our.Umbraco.IoC.Unity")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("f4bcef57-d867-43ee-90da-7ee849bf11b0")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0-beta")]

--- a/src/Our.Umbraco.IoC.Unity/UnityActivator.cs
+++ b/src/Our.Umbraco.IoC.Unity/UnityActivator.cs
@@ -1,0 +1,25 @@
+﻿using Unity.AspNet.Mvc;
+
+
+[assembly: WebActivatorEx.PreApplicationStartMethod(typeof(Our.Umbraco.IoC.Unity.UnityActivator), "Start")]
+[assembly: WebActivatorEx.ApplicationShutdownMethod(typeof(Our.Umbraco.IoC.Unity.UnityActivator), "Shutdown")]
+
+namespace Our.Umbraco.IoC.Unity
+{
+    /// <summary>Provides the bootstrapping for integrating Unity with WebApi when it is hosted in ASP.NET</summary>
+    static class UnityActivator
+    {
+        /// <summary>Integrates Unity when the application starts.</summary>
+        public static void Start()
+        {
+            Microsoft.Web.Infrastructure.DynamicModuleHelper.DynamicModuleUtility.RegisterModule(typeof(UnityPerRequestHttpModule));
+        }
+
+        /// <summary>Disposes the Unity container when the application is shut down.</summary>
+        public static void Shutdown()
+        {
+            var container = UnityConfig.GetConfiguredContainer();
+            container.Dispose();
+        }
+    }
+}

--- a/src/Our.Umbraco.IoC.Unity/UnityConfig.cs
+++ b/src/Our.Umbraco.IoC.Unity/UnityConfig.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Unity;
+
+namespace Our.Umbraco.IoC.Unity
+{
+    /// <summary>
+    /// Specifies the Unity configuration for the main container.
+    /// </summary>
+    public class UnityConfig
+    {
+        private static Lazy<IUnityContainer> container = new Lazy<IUnityContainer>(() => new UnityContainer());
+
+        /// <summary>
+        /// Gets the configured Unity container.
+        /// </summary>
+        public static IUnityContainer GetConfiguredContainer()
+        {
+            return container.Value;
+        }
+    }
+}

--- a/src/Our.Umbraco.IoC.Unity/UnityResolver.cs
+++ b/src/Our.Umbraco.IoC.Unity/UnityResolver.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Unity;
+
+namespace Our.Umbraco.IoC.Unity
+{
+    internal class UnityResolver : Resolver
+    {
+        private IUnityContainer _container;
+        public UnityResolver WithContext(IUnityContainer container)
+        {
+            if (container == null) throw new ArgumentNullException(nameof(container));
+            _container = container;
+            return this;
+        }
+        public override TService Resolve<TService>()
+        {
+            return _container.Resolve<TService>();
+        }
+    }
+}

--- a/src/Our.Umbraco.IoC.Unity/UnityStartup.cs
+++ b/src/Our.Umbraco.IoC.Unity/UnityStartup.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Configuration;
+using System.Web.Http;
+using System.Web.Mvc;
+using Umbraco.Core;
+using Umbraco.Web.Editors;
+using Umbraco.Web.HealthCheck;
+using Umbraco.Web.Trees;
+using Unity;
+using Unity.Injection;
+
+namespace Our.Umbraco.IoC.Unity
+{
+    public class UnityStartup : IApplicationEventHandler
+    {
+        public static EventHandler<ContainerBuildingEventArgs> ContainerBuilding;
+
+        private void OnContainerBuilding(ContainerBuildingEventArgs args)
+        {
+            if (ContainerBuilding != null)
+                ContainerBuilding(this, args);
+        }
+
+        public void OnApplicationInitialized(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
+        {
+        }
+        public void OnApplicationStarting(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
+        {
+        }
+
+        public void OnApplicationStarted(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
+        {
+            ////If this flag exists and it's not 'true' then this container will be disabled.
+            if (ConfigurationManager.AppSettings["Our.Umbraco.IoC.Unity.Enabled"] != null && ConfigurationManager.AppSettings["Our.Umbraco.IoC.Unity.Enabled"] != "true")
+                return;
+
+            var container = UnityConfig.GetConfiguredContainer();
+            container.RegisterWebTypes();
+
+            ////register umbraco types
+            var umbracoRegistrations = new UnityUmbracoRegister(container, UmbracoServices.GetAllRegistrations());
+            umbracoRegistrations.RegisterTypes();
+
+            ////Raise event so people can modify the container
+            OnContainerBuilding(new ContainerBuildingEventArgs(container, applicationContext, umbracoApplication));
+
+            ////set dependency resolvers for both webapi and mvc
+            GlobalConfiguration.Configuration.DependencyResolver = new global::Unity.AspNet.WebApi.UnityDependencyResolver(container);
+            DependencyResolver.SetResolver(new global::Unity.AspNet.Mvc.UnityDependencyResolver(container));
+        }
+    }
+}

--- a/src/Our.Umbraco.IoC.Unity/UnityUmbracoRegister.cs
+++ b/src/Our.Umbraco.IoC.Unity/UnityUmbracoRegister.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Unity;
+using Unity.AspNet.Mvc;
+using Unity.Injection;
+using Unity.Lifetime;
+
+namespace Our.Umbraco.IoC.Unity
+{
+    /// <summary>
+    /// Used to register Umbraco services with Unity
+    /// </summary>
+    class UnityUmbracoRegister
+    {
+        IUnityContainer _container;
+        IEnumerable<IContainerRegistration> _registrations;
+
+        private readonly UnityResolver _resolver = new UnityResolver();
+
+        public UnityUmbracoRegister(IUnityContainer container)
+        {
+            _container = container;
+            _registrations = UmbracoServices.GetAllRegistrations().ToList();
+        }
+
+        public UnityUmbracoRegister(IUnityContainer container, IEnumerable<IContainerRegistration> registrations)
+        {
+            _container = container;
+            _registrations = registrations.ToList();
+        }
+
+        private static LifetimeManager GetLifetime(IContainerRegistration reg)
+        {
+            return reg.Lifetime == Lifetime.Transient
+                ? new TransientLifetimeManager()
+                : reg.Lifetime == Lifetime.ExternallyOwned
+                    ? new ExternallyControlledLifetimeManager()
+                    : reg.Lifetime == Lifetime.Request
+                        ? new PerRequestLifetimeManager()
+                        : (LifetimeManager)new TransientLifetimeManager();
+        }
+
+        public void RegisterTypes()
+        {
+            foreach (var registration in _registrations)
+            {
+                if (registration is IActivatorContainerRegistration activatorRegistration)
+                {
+                    _container.RegisterType(registration.Type, GetLifetime(registration), new InjectionFactory(c => activatorRegistration.Activator(_resolver.WithContext(c))));
+                }
+                else
+                {
+                    _container.RegisterType(registration.Type, GetLifetime(registration));
+                }
+            }
+        }
+    }
+}

--- a/src/Our.Umbraco.IoC.Unity/UnityWebTypesExtensions.cs
+++ b/src/Our.Umbraco.IoC.Unity/UnityWebTypesExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System.Web;
+using System.Web.Hosting;
+using System.Web.Routing;
+using Unity;
+using Unity.AspNet.Mvc;
+using Unity.Injection;
+
+namespace Our.Umbraco.IoC.Unity
+{
+    /// <summary>
+    /// Used to register the common web types for LightInject
+    /// </summary>
+    static class UnityWebTypesExtensions
+    {
+        public static void RegisterWebTypes(this IUnityContainer container)
+        {
+            //these are the same items that are registered with Autofac's AutofacWebTypesModule: https://autofac.org/apidoc/html/DA6737B.htm
+
+            container.RegisterType<HttpContextBase>(new PerRequestLifetimeManager(), new InjectionFactory(c => new HttpContextWrapper(HttpContext.Current)));
+            container.RegisterType<HttpApplicationStateBase>(new PerRequestLifetimeManager(), new InjectionFactory(c => new HttpApplicationStateWrapper(HttpContext.Current.Application)));
+            container.RegisterType<HttpRequestBase>(new PerRequestLifetimeManager(), new InjectionFactory(c => new HttpRequestWrapper(HttpContext.Current.Request)));
+            container.RegisterType<HttpBrowserCapabilitiesBase>(new PerRequestLifetimeManager(), new InjectionFactory(c => new HttpBrowserCapabilitiesWrapper(HttpContext.Current.Request.Browser)));
+            container.RegisterType<HttpFileCollectionBase>(new PerRequestLifetimeManager(), new InjectionFactory(c => new HttpFileCollectionWrapper(HttpContext.Current.Request.Files)));
+            container.RegisterType<RequestContext>(new PerRequestLifetimeManager(), new InjectionFactory(c => HttpContext.Current.Request.RequestContext));
+            container.RegisterType<HttpResponseBase>(new PerRequestLifetimeManager(), new InjectionFactory(c => new HttpResponseWrapper(HttpContext.Current.Response)));
+            container.RegisterType<HttpCachePolicyBase>(new PerRequestLifetimeManager(), new InjectionFactory(c => new HttpCachePolicyWrapper(HttpContext.Current.Response.Cache)));
+            container.RegisterType<HttpServerUtilityBase>(new PerRequestLifetimeManager(), new InjectionFactory(c => new HttpServerUtilityWrapper(HttpContext.Current.Server)));
+            container.RegisterType<HttpSessionStateBase>(new PerRequestLifetimeManager(), new InjectionFactory(c => new HttpSessionStateWrapper(HttpContext.Current.Session)));
+            container.RegisterType<VirtualPathProvider>(new PerRequestLifetimeManager(), new InjectionFactory(c => HostingEnvironment.VirtualPathProvider));
+        }
+    }
+}

--- a/src/Our.Umbraco.IoC.Unity/app.config
+++ b/src/Our.Umbraco.IoC.Unity/app.config
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <system.data>
+    <DbProviderFactories>
+      <remove invariant="MySql.Data.MySqlClient" />
+      <add name="MySQL Data Provider" invariant="MySql.Data.MySqlClient" description=".Net Framework Data Provider for MySQL" type="MySql.Data.MySqlClient.MySqlClientFactory, MySql.Data, Version=6.9.10.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" />
+    </DbProviderFactories>
+  </system.data>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.8.0" newVersion="2.0.8.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Security.OAuth" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Security.Cookies" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="MySql.Data" publicKeyToken="c5687fc88969c44d" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.9.10.0" newVersion="6.9.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Unity.Abstractions" publicKeyToken="6d32ff45e0ccc69f" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.1.0" newVersion="3.1.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Our.Umbraco.IoC.Unity/packages.config
+++ b/src/Our.Umbraco.IoC.Unity/packages.config
@@ -1,0 +1,44 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="AutoMapper" version="3.3.1" targetFramework="net45" />
+  <package id="ClientDependency" version="1.9.2" targetFramework="net45" />
+  <package id="ClientDependency-Mvc5" version="1.8.0.0" targetFramework="net45" />
+  <package id="Examine" version="0.1.88" targetFramework="net45" />
+  <package id="HtmlAgilityPack" version="1.4.9.5" targetFramework="net45" />
+  <package id="ImageProcessor" version="2.5.6" targetFramework="net45" />
+  <package id="ImageProcessor.Web" version="4.8.7" targetFramework="net45" />
+  <package id="log4net" version="2.0.8" targetFramework="net45" />
+  <package id="Log4Net.Async" version="2.0.4" targetFramework="net45" />
+  <package id="Lucene.Net" version="2.9.4.1" targetFramework="net45" />
+  <package id="Markdown" version="1.14.7" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Identity.Core" version="2.2.1" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Identity.Owin" version="2.2.1" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.SignalR.Core" version="2.2.1" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net45" />
+  <package id="Microsoft.IO.RecyclableMemoryStream" version="1.2.2" targetFramework="net45" />
+  <package id="Microsoft.Owin" version="3.1.0" targetFramework="net45" />
+  <package id="Microsoft.Owin.Host.SystemWeb" version="3.1.0" targetFramework="net45" />
+  <package id="Microsoft.Owin.Security" version="3.1.0" targetFramework="net45" />
+  <package id="Microsoft.Owin.Security.Cookies" version="3.1.0" targetFramework="net45" />
+  <package id="Microsoft.Owin.Security.OAuth" version="3.1.0" targetFramework="net45" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
+  <package id="MiniProfiler" version="2.1.0" targetFramework="net45" />
+  <package id="MySql.Data" version="6.9.10" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
+  <package id="Owin" version="1.0" targetFramework="net45" />
+  <package id="semver" version="1.1.2" targetFramework="net45" />
+  <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
+  <package id="System.Threading.Tasks.Dataflow" version="4.7.0" targetFramework="net45" />
+  <package id="UmbracoCms.Core" version="7.7.7" targetFramework="net45" />
+  <package id="Unity.Abstractions" version="3.1.1" targetFramework="net45" />
+  <package id="Unity.AspNet.WebApi" version="5.0.11" targetFramework="net45" />
+  <package id="Unity.Container" version="5.5.2" targetFramework="net45" />
+  <package id="Unity.Mvc" version="5.0.12" targetFramework="net45" />
+  <package id="WebActivatorEx" version="2.2.0" targetFramework="net45" />
+</packages>

--- a/src/Our.Umbraco.IoC.WebTest/Web.config
+++ b/src/Our.Umbraco.IoC.WebTest/Web.config
@@ -64,6 +64,7 @@
 
         <add key="Our.Umbraco.IoC.LightInject.Enabled" value="true" />
         <add key="Our.Umbraco.IoC.Autofac.Enabled" value="false" />
+        <add key="Our.Umbraco.IoC.Unity.Enabled" value="false" />
 
     </appSettings>
     <connectionStrings>

--- a/src/Our.Umbraco.IoC.sln
+++ b/src/Our.Umbraco.IoC.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27004.2005
+VisualStudioVersion = 15.0.27130.2010
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Our.Umbraco.IoC.WebTest", "Our.Umbraco.IoC.WebTest\Our.Umbraco.IoC.WebTest.csproj", "{2EEE5B5F-60E4-46FE-96D6-2D0AF3E50FAD}"
 EndProject
@@ -26,6 +26,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{FA58A0EB
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Our.Umbraco.IoC.LightInject4", "Our.Umbraco.IoC.LightInject4\Our.Umbraco.IoC.LightInject4.csproj", "{FC31DB53-EE45-462B-9315-07FA26C3F2EB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Our.Umbraco.IoC.Unity", "Our.Umbraco.IoC.Unity\Our.Umbraco.IoC.Unity.csproj", "{F4BCEF57-D867-43EE-90DA-7EE849BF11B0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -53,6 +55,10 @@ Global
 		{FC31DB53-EE45-462B-9315-07FA26C3F2EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FC31DB53-EE45-462B-9315-07FA26C3F2EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FC31DB53-EE45-462B-9315-07FA26C3F2EB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F4BCEF57-D867-43EE-90DA-7EE849BF11B0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F4BCEF57-D867-43EE-90DA-7EE849BF11B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F4BCEF57-D867-43EE-90DA-7EE849BF11B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F4BCEF57-D867-43EE-90DA-7EE849BF11B0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
So, how far off am I ? :D

Some notes:
not sure if i did the nuget versioning right?
Unity uses WebAssemblyEx to enable it's per request http module and dispose container on shutdown
Should we be using common service locator interface to generalize the containers ? 

I tested my build on a fresh installation of 7.7.7
I used to need to need explicily register the following:

```
container.RegisterType<HealthCheckController>(new InjectionConstructor());
container.RegisterType<UsersController>(new InjectionConstructor());
container.RegisterType<LegacyTreeController>(new InjectionConstructor());
```

I can understand that the userController works but i can't remember where to test the legacyTreeController and i'm hoping that some magic is resolving the healthCheck options interface as that controller does work in my test.